### PR TITLE
Migrate to Quotable API

### DIFF
--- a/src/middlewares/quotesMiddleware.ts
+++ b/src/middlewares/quotesMiddleware.ts
@@ -1,13 +1,13 @@
-import { Store } from 'redux';
+import { getDaiylyQuoteFailAction, getDaiylyQuoteSuccessAction } from 'actions';
 import { GET_DAILY_QUOTE } from 'actions/types';
-import { quotesService } from 'services/quotes/quotesService';
-import { getDaiylyQuoteSuccessAction, getDaiylyQuoteFailAction } from 'actions';
+import { Store } from 'redux';
+import { quotableService } from 'services/quotes/quotableService';
 
 export const quotesMiddleware = (store: Store) => (next) => async (action) => {
   const nextAction = next(action);
 
   if (action.type === GET_DAILY_QUOTE) {
-    const quote = await quotesService.getDailyQuote('inspire');
+    const quote = await quotableService.getDailyQuote();
 
     if (!quote) {
       store.dispatch(getDaiylyQuoteFailAction());

--- a/src/services/quotes/quotableService.ts
+++ b/src/services/quotes/quotableService.ts
@@ -1,0 +1,20 @@
+import { stitchClient } from 'stitch/client';
+import { IQuote } from 'types/IQuote';
+import { IQuotesService } from './IQuotesService';
+
+class QuotableService implements IQuotesService {
+  getDailyQuote: () => Promise<IQuote | undefined> = async () => {
+    try {
+      const quote = await stitchClient.callFunction('getQuoteOfDay', []);
+
+      return {
+        author: quote.author,
+        text: quote.content
+      };
+    } catch (e) {
+      console.error(e);
+    }
+  };
+}
+
+export const quotableService = new QuotableService();


### PR DESCRIPTION
Quotable API is using for the quote of day.
Quote of day is cashing in `getQuoteOfDay` serverless function.